### PR TITLE
GitHub Actions Checks: Submit the checks in batches

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ const SeverityConversion: {
     .readFile('/tmp/results.json', 'utf8')
     .then((f: string) => JSON.parse(f))) as ThemeCheckReport[];
 
-  const annotations: Octokit.ChecksCreateParamsOutputAnnotations[] =
+  const allAnnotations: Octokit.ChecksCreateParamsOutputAnnotations[] =
     result.flatMap((report: ThemeCheckReport) =>
       report.offenses.map((offense) => ({
         path: path.join(themeRoot || '.', report.path),
@@ -95,41 +95,65 @@ const SeverityConversion: {
     .map((x) => x.suggestionCount)
     .reduce((a, b) => a + b, 0);
 
-  console.log('Updating GitHub check...');
+  const splitIntoChunks = (
+    allAnnotations: Octokit.ChecksCreateParamsOutputAnnotations[],
+  ) => {
+    const chunks: Octokit.ChecksCreateParamsOutputAnnotations[][] = [];
+    // this is Octokit/Checks API annotations limit
+    // https://docs.github.com/en/developers/apps/guides/creating-ci-tests-with-the-checks-api#step-24-collecting-rubocop-errors
+    const CHUNK_SIZE = 50;
+
+    let i = 0;
+    let nextChunk = allAnnotations.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    while (nextChunk.length > 0) {
+      chunks.push(nextChunk);
+      i++;
+      nextChunk = allAnnotations.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    }
+
+    return chunks;
+  };
+  const annotationsChunks = splitIntoChunks(allAnnotations);
+
+  console.log('Updating GitHub Checks...');
 
   // Update check
-  await octokit.checks.update({
-    owner: ctx.repo.owner,
-    repo: ctx.repo.repo,
-    check_run_id: check.data.id,
-    name: CHECK_NAME,
-    status: 'completed',
-    conclusion: exitCode > 0 ? 'failure' : 'success',
-    output: {
-      title: CHECK_NAME,
-      summary: `${errorCount} error(s), ${suggestionCount} warning(s) found`,
-      text: markdown`
-        ## Configuration
-        #### Actions Input
-        | Name | Value |
-        | ---- | ----- |
-        | theme_root | \`${themeRoot || '(not provided)'}\` |
-        | flags | \`${flags || '(not provided)'}\` |
-        | version | \`${version || '(not provided)'}\` |
-        #### ThemeCheck Configuration
-        \`\`\`yaml
-        __CONFIG_CONTENT__
-        \`\`\`
-        </details>
-      `.replace(
-        '__CONFIG_CONTENT__',
-        await exec(`theme-check --print ${themeRoot}`).then(
-          (o: any) => o.stdout,
-        ),
-      ),
-      annotations,
-    },
-  });
+  await Promise.all(
+    annotationsChunks.map(async (annotations) =>
+      octokit.checks.update({
+        owner: ctx.repo.owner,
+        repo: ctx.repo.repo,
+        check_run_id: check.data.id,
+        name: CHECK_NAME,
+        status: 'completed',
+        conclusion: exitCode > 0 ? 'failure' : 'success',
+        output: {
+          title: CHECK_NAME,
+          summary: `${errorCount} error(s), ${suggestionCount} warning(s) found`,
+          text: markdown`
+            ## Configuration
+            #### Actions Input
+            | Name | Value |
+            | ---- | ----- |
+            | theme_root | \`${themeRoot || '(not provided)'}\` |
+            | flags | \`${flags || '(not provided)'}\` |
+            | version | \`${version || '(not provided)'}\` |
+            #### ThemeCheck Configuration
+            \`\`\`yaml
+            __CONFIG_CONTENT__
+            \`\`\`
+            </details>
+          `.replace(
+            '__CONFIG_CONTENT__',
+            await exec(`theme-check --print ${themeRoot}`).then(
+              (o: any) => o.stdout,
+            ),
+          ),
+          annotations,
+        },
+      }),
+    ),
+  );
 })().catch((e) => {
   console.error(e.stack); // tslint:disable-line
   core.setFailed(e.message);


### PR DESCRIPTION
This is needed because GitHub Actions Checks API limits the number of annotations to a maximum of 50 per API request. To create more than 50 annotations, you have to make multiple requests to the Update a check run endpoint.
https://docs.github.com/en/developers/apps/guides/creating-ci-tests-with-the-checks-api#step-24-collecting-rubocop-errors

Closes #6
Action fails with: Error: Invalid request. No more than 50 items are allowed; 404 were supplied.


More people having this issue (just 2 random repos, but there are more):
* https://github.com/kamilkisiela/graphql-inspector/issues/1840
* https://github.com/krizzu/eslint-check-action/issues/1

Their fixes are similar to mine:
* https://github.com/kamilkisiela/graphql-inspector/pull/1854/files#diff-0a970ccd424238bd8c3d97fc7bb2ec8bc75217755a2b49226505d992a576f272
* https://github.com/krizzu/eslint-check-action/pull/3/files#diff-6792c56d44770cf1d5b0125f86f9653f158c86d23ca1227509c47fd75e6a3ff6


Test steps:

1. In any repo where theme-check-action is used (preferably repo with more than 50 theme-check issues), switch to vfonic fork:

  ```diff
  name: Theme Check
  on: [push]
  jobs:
    theme-check:
      name: Theme Check
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v2
        - name: Theme Check
  -        uses: shopify/theme-check-action@v1
  +        uses: vfonic/theme-check-action@batch-octokit-annotations
          with:
            theme_root: '.'
            token: ${{ github.token }}
  ```

2. Push the change to some branch and check how the Action runs



I believe, but I didn't properly test to confirm, that I'm making these Checks update requests in parallel. This means that, if there are 2000 errors, this will make 2000 / 50 = 40 requests at the same time. 

I tested this if it will timeout or get rate limited, and it doesn't. It does slow down as it needs to make all those requests. It slows down by approx 1s per 100 annotations (it seems to be able to make 2 requests per second(?), but I'm not sure as I'm supposedly making all of these requests at once?).
I ran this action on a repo with 2207 theme-check issues.

Here are my findings:
There's an undocumented limit of 1000 annotations. I searched GH Actions documentation and couldn't find anything about the upper limit, only 50 annotations limit per request.

I tested with updating Checks in parallel and consecutively.

Running in parallel:

```ts
await Promise.all(
    annotationsChunks.map(async (annotations) =>
      octokit.checks.update({
        // ...
```

Running consecutively:

```ts
annotationsChunks.forEach(
    async (annotations) =>
      await octokit.checks.update({
        // ...
```

<details>
<summary>Results</summary>

| Parallel             |  Consecutively |
|:-------------------------:|:-------------------------:|
| Errors reported ![Screen Shot 2022-02-26 at 12 40 07](https://user-images.githubusercontent.com/67437/155831063-6ef14d57-07f3-4ffa-a16b-9e652d17fcaa.jpg) | Errors reported ![Screen Shot 2022-02-26 at 12 36 57](https://user-images.githubusercontent.com/67437/155831075-a58f9ea8-199d-404b-b4ad-8a2840728b8e.jpg) |
| Action run time and number of annotations ![Screen Shot 2022-02-26 at 12 40 25](https://user-images.githubusercontent.com/67437/155831112-b1be6f7c-7b0a-456a-94a6-c56a754a9907.jpg) | Action run time and number of annotations ![Screen Shot 2022-02-26 at 12 37 15](https://user-images.githubusercontent.com/67437/155831126-8947b8d7-f281-4288-889f-5a645f1742fa.jpg) |
</details>


There seems to be a race condition when doing Checks update. It always reports 1000 annotations. However, it always reports 1000 different annotations.
I tested this for both "parallel job" and "consecutive job" (code posted above).

It only seems that "parallel job" runs some ~10 seconds faster so I kept that code here in the PR.

In my defense for having a theme with 2000+ errors...YOU'RE WELCOME! (for the great testing material! 😅 )