### PR TITLE
Add `base` input argument to only annotate diff'ed files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cpclermont/theme-check-action:1.0.1
+FROM cpclermont/theme-check-action:1.0.2
 
 COPY entrypoint.sh /entrypoint.sh
 COPY index.js /index.js

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,5 +6,5 @@ COPY package.json package-lock.json /var/task/
 
 # Install dependencies
 RUN apk add --update \
-    && apk add ruby ruby-nokogiri bash \
+    && apk add ruby ruby-nokogiri bash git \
     && cd /var/task && npm ci --production

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := cpclermont/theme-check-action
-VERSION := 1.0.1
+VERSION := 1.0.2
 GITSHA:= $(shell echo $$(git describe --always --long --dirty))
 
 export GITSHA

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jobs:
         with:
           theme_root: '.' # optional, could be './dist'
           token: ${{ github.token }}
+          base: main
 ```
 
 ## Configuration
@@ -37,3 +38,4 @@ The `shopify/theme-check-action` accepts the following arguments:
 * `flags` - (optional) theme-check command line flags. (e.g. `'--fail-level suggestion'`)
 * `version` - (optional, default: latest) specific theme-check version to use.
 * `token` - (optional) result of `${{ github.token }}` to enable GitHub check annotations.
+* `base` - (optional) When `token` is set, only the files that contain a diff with this ref (branch, tag or commit) will have GitHub check annotations.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   token:
     description: 'GitHub token so that the action can annotate the checks'
     required: false
+  base:
+    description: 'When token is set, only the files that contain a diff with this ref (branch, tag or commit) will have GitHub annotations.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
In this PR, we add support for the `base` input argument. It can be a git branch, tag or commit sha.

When this is set as well as the `token` input argument, only the files containing diffs will receive GitHub check annotations.

This should help curb the 1000 annotation limit for folks dealing with legacy themes.

Example configuration:

```yaml
  theme-check:
    name: Theme Check
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Theme Check
        uses: shopify/theme-check-action@v1
        with:
          token: ${{ github.token }}
          base: main
```

- [Demo run with failures](https://github.com/Shopify/theme-check-action/actions/runs/1912014350)
- [Demo run without failures](https://github.com/Shopify/theme-check-action/runs/5364234230?check_suite_focus=true)

Fixes #3
