### PR TITLE
Update to actions/checkout@v3 for Node 16 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: "shopify/dawn"
           path: "./dawn"
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: "shopify/dawn"
           path: "./dawn"
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: "shopify/dawn"
           path: "./dawn"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     name: Theme Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Theme Check
         uses: shopify/theme-check-action@v1
         with:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow and README documentation to use `actions/checkout@v3`. This change is necessary to ensure compatibility with the latest GitHub Actions runner environment, which now defaults to Node.js version 16. The change is in response to the deprecation of Node.js 12 and GitHub's move to enforce Node.js 16 in all workflows.

Warning produced by continue using `actions/checkout@v2` in the GHA:
```
Theme Check
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

__Background:__

As of June 13, 2023, GitHub announced the deprecation of Node.js 12, which has been out of support since April 2022. In compliance with this, all actions are required to run on Node.js 16. 
Notice from Github: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

__Testing:__
GHA now use Node 16 by default unless specified with `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. I've tested this change on a repo of ours and it works as expected, screenshot displaying exit code 0.
<img width="832" alt="Screenshot 2024-01-05 at 03 25 09" src="https://github.com/Shopify/theme-check-action/assets/904697/fa96fbc2-663f-414b-b397-65ec361ae1cc">

