### PR TITLE
Use Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ inputs:
     description: 'When token is set, only the files that contain a diff with this ref (branch, tag or commit) will have GitHub annotations.'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
This github action is starting to throw warnings about using Node 20. This PR upgrades the action to use node 24 instead.

Node 20 is EOL in April of 2026.

I did a quick skim of node 20 vs node 24 and I don't think this action is going to be using any of the things that had breaking changes.